### PR TITLE
Ensure convex hull iteration counter always advances

### DIFF
--- a/lib/utils/sun_utils.dart
+++ b/lib/utils/sun_utils.dart
@@ -433,13 +433,15 @@ class SunUtils {
     final int maxIterations = uniquePointList.length * 2 + 5; // Increased slightly
 
     do {
+      iteration++; // Ensure iteration count always advances
       // Safeguard: if we are re-adding a point (other than start) or exceed iterations.
-      if (hullIndices.contains(currentPointIndex) && currentPointIndex != startPointIndex || iteration++ > maxIterations) {
+      if ((hullIndices.contains(currentPointIndex) && currentPointIndex != startPointIndex) ||
+          iteration > maxIterations) {
         if (kDebugMode) {
           print("Convex Hull Error: Loop detected or exceeded max iterations ($iteration > $maxIterations). Aborting. Hull size: ${hull.length}, Input size: ${uniquePointList.length}");
         }
         // Return what we have if it's somewhat valid, or empty if too small.
-        return hull.length >=3 ? hull : [];
+        return hull.length >= 3 ? hull : [];
       }
 
       hull.add(uniquePointList[currentPointIndex]);


### PR DESCRIPTION
## Summary
- prevent potential infinite loops in convex hull calculation by always incrementing the iteration counter

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898742cd72c8328abe7fe431ad66d93