### PR TITLE
Add listener notification when fly-to handled

### DIFF
--- a/lib/providers/map_state.dart
+++ b/lib/providers/map_state.dart
@@ -69,6 +69,7 @@ class MapState with ChangeNotifier {
     if (_flyToPlaceNeeded) {
       _flyToPlaceNeeded = false;
       if (kDebugMode) print("MapState: Fly-to handled, flag reset.");
+      _safeNotifyListeners();
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure MapState notifies listeners after fly-to is handled so UI reacts to state change

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689878fcdb448328a4d58969fe849c5e